### PR TITLE
Remove soft border around pie chart

### DIFF
--- a/jquery.peity.js
+++ b/jquery.peity.js
@@ -55,7 +55,7 @@
       // Plate.
       canvas.beginPath();
       canvas.moveTo(centre, centre);
-      canvas.arc(centre, centre, centre, 0, Math.PI * 2, false);
+      canvas.arc(centre, centre, centre, slice + adjust, adjust, false);
       canvas.fillStyle = opts.colours[0];
       canvas.fill();
 


### PR DESCRIPTION
When the pie has a darker plate color then the slice, a little border appears around the slice of the pie. It can be solved by not creating a full circle as the plate.
