### PR TITLE
Fix missing Github ribbon

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@ $(function() {
     <dd><a href="https://github.com/benpickles/peity">github.com/benpickles/peity</a></dd>
   </dl>
 
-  <a href="http://github.com/benpickles/peity" id="fork-me"><img alt="Fork me on GitHub" src="https://a248.e.akamai.net/assets.github.com/img/e6bef7a091f5f3138b8cd40bc3e114258dd68ddf/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67"></a>
+  <a href="https://github.com/benpickles/peity"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
   <h2 id="pie-charts">Pie Charts</h2>
 


### PR DESCRIPTION
The Github ribbon seems to have changed locations, this change should fix it.  I'm not sure what colour the ribbon used to be so I chose you a classy black colour, black is the new black after all.
