### PR TITLE
Automatically apply data attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,31 +316,30 @@ $("span.graph")
   })</code></pre>
   </div>
     
-  <h3>Per-element Colour and Diameter (implicit)</h3>
+  <h3>Per-element Colour and Diameter (via data-* attributes)</h3>
 
-  <p>If you use data attributes, Peity will apply their values to the defaults with the same names automatically. Note data-colour is special case in pie type (whose defaults consist of a data-colours with the 's').</p>
+  <p>If you use data attributes, Peity will apply their values to the defaults with the same names automatically.</p>
 
   <p class="pie">
-    <span data-colours="red" data-diameter="40">1/7</span>
-    <span data-colours="#eeeeee, orange" data-diameter="36">2/7</span>
-    <span data-colours="yellow" data-diameter="32">3/7</span>
-    <span data-colours="green" data-diameter="28">4/7</span>
-    <span data-colours="blue" data-diameter="24">5/7</span>
-    <span data-colours="indigo" data-diameter="20">6/7</span>
-    <span data-colours="violet" data-diameter="16">7/7</span>
+    <span data-colours='["#eeeeee", "red"]' data-diameter="40">1/7</span>
+    <span data-colours='["#eeeeee", "orange"]' data-diameter="36">2/7</span>
+    <span data-colours='["#eeeeee", "yellow"]' data-diameter="32">3/7</span>
+    <span data-colours='["#eeeeee", "green"]' data-diameter="28">4/7</span>
+    <span data-colours='["#eeeeee", "blue"]' data-diameter="24">5/7</span>
+    <span data-colours='["#eeeeee", "indigo"]' data-diameter="20">6/7</span>
+    <span data-colours='["#eeeeee", "violet"]' data-diameter="16">7/7</span>
   </p>
 
   <div class="example">
     <h4>HTML</h4>
 
-    <pre><code class="html">&lt;span data-colours=&quot;red&quot;    data-diameter=&quot;40&quot;&gt;1/7&lt;/span&gt;
-&lt;span data-colours=&quot;#eeeeee, orange&quot; data-diameter=&quot;36&quot;&gt;2/7&lt;/span&gt;
-&lt;span data-colours=&quot;yellow&quot; data-diameter=&quot;32&quot;&gt;3/7&lt;/span&gt;
-&lt;span data-colours=&quot;green&quot;  data-diameter=&quot;28&quot;&gt;4/7&lt;/span&gt;
-&lt;span data-colours=&quot;blue&quot;   data-diameter=&quot;24&quot;&gt;5/7&lt;/span&gt;
-&lt;span data-colours=&quot;indigo&quot; data-diameter=&quot;20&quot;&gt;6/7&lt;/span&gt;
-&lt;span data-colours=&quot;violet&quot; data-diameter=&quot;16&quot;&gt;7/7&lt;/span&gt;</code></pre>
-
+    <pre><code class="html">&lt;span data-colours=&#39;[&quot;#eeeeee&quot;, &quot;red&quot;]&#39;    data-diameter=&quot;40&quot;&gt;2/7&lt;/span&gt;
+&lt;span data-colours=&#39;[&quot;#eeeeee&quot;, &quot;orange&quot;]&#39; data-diameter=&quot;36&quot;&gt;2/7&lt;/span&gt;
+&lt;span data-colours=&#39;[&quot;#eeeeee&quot;, &quot;yellow&quot;]&#39; data-diameter=&quot;32&quot;&gt;3/7&lt;/span&gt;
+&lt;span data-colours=&#39;[&quot;#eeeeee&quot;, &quot;green&quot;]&#39;  data-diameter=&quot;28&quot;&gt;4/7&lt;/span&gt;
+&lt;span data-colours=&#39;[&quot;#eeeeee&quot;, &quot;blue&quot;]&#39;   data-diameter=&quot;24&quot;&gt;5/7&lt;/span&gt;
+&lt;span data-colours=&#39;[&quot;#eeeeee&quot;, &quot;indigo&quot;]&#39; data-diameter=&quot;20&quot;&gt;6/7&lt;/span&gt;
+&lt;span data-colours=&#39;[&quot;#eeeeee&quot;, &quot;violet&quot;]&#39; data-diameter=&quot;16&quot;&gt;7/7&lt;/span&gt;</code></pre>
     <h4>JavaScript</h4>
 
     <pre><code class="javascript">$(&quot;.pie span&quot;).peity(&quot;pie&quot;)</code></pre>

--- a/jquery.peity.js
+++ b/jquery.peity.js
@@ -9,26 +9,17 @@
     if (document.createElement("canvas").getContext) {
       this.each(function() {
         $(this).change(function() {
-          var opts = $.extend({}, peity.defaults[type], options)
-          var self = this
           var defaults = peity.defaults[type];
+          var opts = $.extend({}, defaults, options)
+          var self = this
    
+          $.each($(this).data(), function(name, value) {
+            if (defaults[name] && (!options || !options[name])) opts[name] = value
+          })
+          
           $.each(opts, function(name, value) {
             if ($.isFunction(value)) opts[name] = value.call(self)
-          });
-
-          $.each($(this).data(), function(name, value) {
-            if (defaults[name] && !opts[name]) {
-              if (name === 'colours') {
-                var colours = value.split(',');
-                if (colours.length == 1)
-                  value = [defaults['colours'][0], value];
-                else if (colours.length >= 2)
-                  value = $.map(colours, function(c) { return $.trim(c); });
-              }
-              opts[name] = value;
-            }
-          });
+          })
 
           var value = $(this).html();
           peity.graphers[type].call(this, opts)


### PR DESCRIPTION
When users define data-colour, data-diameter etc. (with those after the 'data-' prefix matching properties of defaults), apply them automatically instead of requiring writing custom functions.
