### PR TITLE
Load jQuery with a relative protocol URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta name="viewport" content="width=device-width">
 <title>Peity &bull; progressive &lt;svg&gt; pie charts</title>
 <link href="docs/style.css" rel="stylesheet">
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
 <script src="jquery.peity.js"></script>
 <script>
 $(function() {


### PR DESCRIPTION
In Chrome 36.0.1985.125 on OSX 10.9.4 I get this error:

[blocked] The page at 'https://benpickles.github.io/peity/' was loaded over HTTPS, but ran insecure content from 'http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js': this content should also be loaded over HTTPS.

This is fixed by making the URL protocol-relative.
