### PR TITLE
Add value_attr to pie chart nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ jquery.peity.min.js.gz
 /node_modules
 /test/comparisons
 /test/images
+.idea/*

--- a/index.html
+++ b/index.html
@@ -482,6 +482,21 @@ setInterval(function() {
 $('span.graph').peity('pie')</code></pre>
   </div>
 
+  <h2 id="tooltips">Tooltip Setup</h2>
+
+  <p>You can add a <code>value_attr</code> setting to the pie and donut charts so that tooltip plugins such as Bootstrap tooltip can display values when hovering over a pie slice. This works by adding an attribute (e.g. 'title' or 'data-value') as defined in value_attr to each svg path or circle created. For example (and this assumes you have jQuery and Bootstrap set up):</p>
+  <h4>JavaScript</h4>
+
+  <pre><code class="javascript">$(document).ready( function() {
+  $.fn.peity.defaults.pie = {
+    fill: ["#d9534f", "#5cb85c", "#f5f5f5"],
+    radius: 20,
+    value_attr: 'title'
+  };
+  $('span.pie').peity("pie");
+  $("svg.peity > path, svg.peity > circle").tooltip({container: 'body', placement: 'auto top' });
+});</code></pre>
+
   <h2 id="defaults">Default Settings</h2>
 
   <p>Defaults can be overridden globally like so:</p>
@@ -491,7 +506,8 @@ $('span.graph').peity('pie')</code></pre>
   fill: ["<span style="background:#ff9900">#ff9900</span>", "<span style="background:#fff4dd">#fff4dd</span>", "<span style="background:#ffd592">#ffd592</span>"],
   height: null,
   radius: 8,
-  width: null
+  width: null,
+  value_attr: 'title'
 }
 
 $.fn.peity.defaults.donut = {
@@ -525,6 +541,12 @@ $.fn.peity.defaults.bar = {
 }</code></pre>
 
   <div class="changelog"><h2 id="changelog">CHANGELOG</h2>
+
+<h3>Version 3.2.1rc - 2016/6/09</h3>
+
+<ul>
+  <li>Add a <code>value_attr</code> setting so that tooltips can display values when hovering over a pie slice.</li>
+</ul>
 
 <h3>Version 3.2.0 - 2015/4/17</h3>
 

--- a/jquery.peity.js
+++ b/jquery.peity.js
@@ -224,6 +224,9 @@
         }
 
         $node.attr('fill', fill.call(this, value, i, values))
+        if (opts.value_attr) {
+          $node.attr(opts.value_attr, value)
+        }
 
         $svg.append($node)
       }


### PR DESCRIPTION
Dear Ben - I have added a new setting to help tooltip plugins such as Bootstrap tooltip display values when hovering over a pie slice. The only problem is I don't now how to bump the version properly, or to compile into the minified version. I have added some documentation into index.html. Please feel free to ignore the request but I saw some other people had discussed this so I thought I would put it out there..
